### PR TITLE
Auto promote master branch to Heroku after CI passed

### DIFF
--- a/.semaphore/heroku.yml
+++ b/.semaphore/heroku.yml
@@ -1,0 +1,25 @@
+version: v1.0
+name: Deploy to Heroku
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu1804
+
+blocks:
+  - name: Deploy
+    task:
+      secrets:
+        - name: rails-base-graphql-api-heroku
+      env_vars:
+        - name: HEROKU_REMOTE
+          value: https://git.heroku.com/rails-base-graphql-api.git
+      jobs:
+        - name: Deploy to Heroku
+          commands:
+          - checkout --use-cache
+          - ssh-keyscan -H heroku.com >> ~/.ssh/known_hosts
+          - chmod 600 ~/.ssh/id_rsa_rails_base_graphql_api_heroku
+          - ssh-add ~/.ssh/id_rsa_rails_base_graphql_api_heroku
+          - git config --global url.ssh://git@heroku.com/.insteadOf https://git.heroku.com/
+          - git remote add heroku $HEROKU_REMOTE
+          - git push heroku -f $SEMAPHORE_GIT_BRANCH:master

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -61,3 +61,9 @@ blocks:
         - name: Test
           commands:
             - bin/tests
+
+promotions:
+  - name: Deploy to Heroku
+    pipeline_file: heroku.yml
+    auto_promote:
+      when: "result = 'passed' and branch = 'master'"


### PR DESCRIPTION
### Summary

This PR adds auto promote from Semaphore CI to Heroku if all checks passed and branch name is 'master'

### Review notes

While reviewing pull-request (especially when it's your pull-request),
please make sure that:

- you understand what problem is solved by PR and how is it solved
- new tests are in place, no redundant tests
- DB schema changes reflect new migrations
- newly introduced DB fields have indexes and constraints
- there are no missed files (migrations, view templates)
- required ENV variables added and described in `.env.example` and added to Heroku
- associated Heroku review app works correctly with introduced changes

### Deploy notes

I guess we need to disable Automatic deploy from GitHub before this PR will be merged

### References
* GitHub Issue #21 
