### PR TITLE
Use shared examples for GraphQL requests

### DIFF
--- a/spec/fixtures/json/acceptance/graphql/query_type_me.json
+++ b/spec/fixtures/json/acceptance/graphql/query_type_me.json
@@ -1,0 +1,1 @@
+{"data":{"me":{"id":":id","email":":email","firstName":":first_name","lastName":":last_name"}}}

--- a/spec/fixtures/json/acceptance/graphql/query_type_me.json
+++ b/spec/fixtures/json/acceptance/graphql/query_type_me.json
@@ -1,1 +1,10 @@
-{"data":{"me":{"id":":id","email":":email","firstName":":first_name","lastName":":last_name"}}}
+{
+  "data": {
+    "me": {
+      "id": ":id",
+      "email": ":email",
+      "firstName": ":first_name",
+      "lastName": ":last_name"
+    }
+  }
+}

--- a/spec/fixtures/json/acceptance/graphql/signin.json
+++ b/spec/fixtures/json/acceptance/graphql/signin.json
@@ -1,1 +1,11 @@
-{"data":{"signin":{"token":":token","me":{"id":":id","email":"bilbo.baggins@shire.com"}}}}
+{
+  "data": {
+    "signin": {
+      "token": ":token",
+      "me": {
+        "id": ":id",
+        "email": "bilbo.baggins@shire.com"
+      }
+    }
+  }
+}

--- a/spec/fixtures/json/acceptance/graphql/signin.json
+++ b/spec/fixtures/json/acceptance/graphql/signin.json
@@ -1,0 +1,1 @@
+{"data":{"signin":{"token":":token","me":{"id":":id","email":"bilbo.baggins@shire.com"}}}}

--- a/spec/fixtures/json/acceptance/graphql/signin_wrong.json
+++ b/spec/fixtures/json/acceptance/graphql/signin_wrong.json
@@ -1,1 +1,19 @@
-{"data":{"signin":null},"errors":[{"message":"Invalid credentials","extensions":{"status":401,"code":"unauthorized","detail":null},"locations":[{"line":2,"column":9}],"path":["signin"]}]}
+{
+  "data": {
+    "signin": null
+  },
+  "errors": [
+    {
+      "message": "Invalid credentials",
+      "extensions": {
+        "status": 401,
+        "code": "unauthorized",
+        "detail": null
+      },
+      "locations": [
+        { "line": 2, "column": 9 }
+      ],
+      "path": ["signin"]
+    }
+  ]
+}

--- a/spec/fixtures/json/acceptance/graphql/signin_wrong.json
+++ b/spec/fixtures/json/acceptance/graphql/signin_wrong.json
@@ -1,0 +1,1 @@
+{"data":{"signin":null},"errors":[{"message":"Invalid credentials","extensions":{"status":401,"code":"unauthorized","detail":null},"locations":[{"line":2,"column":9}],"path":["signin"]}]}

--- a/spec/fixtures/json/acceptance/graphql/signup.json
+++ b/spec/fixtures/json/acceptance/graphql/signup.json
@@ -1,0 +1,1 @@
+{"data":{"signup":{"me":{"id":":id","email":"bilbo.baggins@shire.com"},"token":":token"}}}

--- a/spec/fixtures/json/acceptance/graphql/signup.json
+++ b/spec/fixtures/json/acceptance/graphql/signup.json
@@ -1,1 +1,11 @@
-{"data":{"signup":{"me":{"id":":id","email":"bilbo.baggins@shire.com"},"token":":token"}}}
+{
+  "data": {
+    "signup": {
+      "me": {
+        "id": ":id",
+        "email": "bilbo.baggins@shire.com"
+      },
+      "token": ":token"
+    }
+  }
+}

--- a/spec/fixtures/json/acceptance/graphql/signup_wrong.json
+++ b/spec/fixtures/json/acceptance/graphql/signup_wrong.json
@@ -1,0 +1,1 @@
+{"data":{"signup":null},"errors":[{"message":"Record Invalid","extensions":{"status":422,"code":"unprocessable_entity","detail":["Email is invalid"]},"locations":[{"line":2,"column":9}],"path":["signup"]}]}

--- a/spec/fixtures/json/acceptance/graphql/signup_wrong.json
+++ b/spec/fixtures/json/acceptance/graphql/signup_wrong.json
@@ -1,1 +1,19 @@
-{"data":{"signup":null},"errors":[{"message":"Record Invalid","extensions":{"status":422,"code":"unprocessable_entity","detail":["Email is invalid"]},"locations":[{"line":2,"column":9}],"path":["signup"]}]}
+{
+  "data": {
+    "signup": null
+  },
+  "errors": [
+    {
+      "message": "Record Invalid",
+      "extensions": {
+        "status": 422,
+        "code": "unprocessable_entity",
+        "detail": ["Email is invalid"]
+      },
+      "locations": [
+        { "line": 2, "column": 9 }
+      ],
+      "path": ["signup"]
+    }
+  ]
+}

--- a/spec/fixtures/json/acceptance/graphql/update_user.json
+++ b/spec/fixtures/json/acceptance/graphql/update_user.json
@@ -1,0 +1,1 @@
+{"data":{"updateUser":{"me":{"id":":id","email":"new_email_11@example.com","firstName":"Randle","lastName":"McMurphy"}}}}

--- a/spec/fixtures/json/acceptance/graphql/update_user.json
+++ b/spec/fixtures/json/acceptance/graphql/update_user.json
@@ -1,1 +1,12 @@
-{"data":{"updateUser":{"me":{"id":":id","email":"new_email_11@example.com","firstName":"Randle","lastName":"McMurphy"}}}}
+{
+  "data": {
+    "updateUser": {
+      "me": {
+        "id": ":id",
+        "email": "new_email_11@example.com",
+        "firstName": "Randle",
+        "lastName": "McMurphy"
+      }
+    }
+  }
+}

--- a/spec/graphql/mutations/sign_in_spec.rb
+++ b/spec/graphql/mutations/sign_in_spec.rb
@@ -24,7 +24,7 @@ describe Mutations::SignIn do
   context "with valid credentials" do
     let(:password) { "TheRing" }
 
-    it_behaves_like "graphql_request", "gets user token" do
+    it_behaves_like "graphql request", "gets user token" do
       let(:fixture_path) { "json/acceptance/graphql/signin.json" }
       let(:prepared_fixture_file) do
         fixture_file.gsub(
@@ -39,7 +39,7 @@ describe Mutations::SignIn do
   context "with invalid credentials" do
     let(:password) { "Sauron" }
 
-    it_behaves_like "graphql_request", "returns error" do
+    it_behaves_like "graphql request", "returns error" do
       let(:fixture_path) { "json/acceptance/graphql/signin_wrong.json" }
     end
   end

--- a/spec/graphql/mutations/sign_in_spec.rb
+++ b/spec/graphql/mutations/sign_in_spec.rb
@@ -1,7 +1,6 @@
 require "rails_helper"
 
 describe Mutations::SignIn do
-  let(:response) { ApplicationSchema.execute(query, {}).as_json }
   let(:query) do
     <<-GRAPHQL
       mutation {
@@ -24,54 +23,24 @@ describe Mutations::SignIn do
 
   context "with valid credentials" do
     let(:password) { "TheRing" }
-    let(:expected_response) do
-      {
-        "data" => {
-          "signin" => {
-            "token" => token,
-            "me" => {
-              "id" => user.id.to_s,
-              "email" => "bilbo.baggins@shire.com"
-            }
-          }
-        }
-      }
-    end
 
-    it "gets user token" do
-      expect(response).to eq expected_response
+    it_behaves_like "graphql_request", "gets user token" do
+      let(:fixture_path) { "json/acceptance/graphql/signin.json" }
+      let(:prepared_fixture_file) do
+        fixture_file.gsub(
+          /:id|:token/,
+          ":id" => user.id,
+          ":token" => token
+        )
+      end
     end
   end
 
   context "with invalid credentials" do
     let(:password) { "Sauron" }
-    let(:expected_response) do
-      {
-        "data" => {
-          "signin" => nil
-        },
-        "errors" => [
-          {
-            "message" => "Invalid credentials",
-            "extensions" => {
-              "status" => 401,
-              "code" => "unauthorized",
-              "detail" => nil
-            },
-            "locations" => [
-              {
-                "line" => 2,
-                "column" => 9
-              }
-            ],
-            "path" => ["signin"]
-          }
-        ]
-      }
-    end
 
-    it "returns error" do
-      expect(response).to eq expected_response
+    it_behaves_like "graphql_request", "returns error" do
+      let(:fixture_path) { "json/acceptance/graphql/signin_wrong.json" }
     end
   end
 end

--- a/spec/graphql/mutations/sign_up_spec.rb
+++ b/spec/graphql/mutations/sign_up_spec.rb
@@ -1,8 +1,6 @@
 require "rails_helper"
 
 describe Mutations::SignUp do
-  let(:response) { ApplicationSchema.execute(query, {}).as_json }
-
   let(:registered_user) { User.first }
   let(:token) { JWT.encode({ sub: registered_user.id }, nil, "none") }
 
@@ -25,54 +23,24 @@ describe Mutations::SignUp do
 
   context "with valid data" do
     let(:email) { "bilbo.baggins@shire.com" }
-    let(:expected_response) do
-      {
-        "data" => {
-          "signup" => {
-            "me" => {
-              "id" => registered_user.id.to_s,
-              "email" => email
-            },
-            "token" => token
-          }
-        }
-      }
-    end
 
-    it "registers a new user" do
-      expect(response).to eq expected_response
+    it_behaves_like "graphql_request", "registers a new user" do
+      let(:fixture_path) { "json/acceptance/graphql/signup.json" }
+      let(:prepared_fixture_file) do
+        fixture_file.gsub(
+          /:id|:token/,
+          ":id" => registered_user.id,
+          ":token" => token
+        )
+      end
     end
   end
 
   context "with invalid data" do
     let(:email) { "bilbo.baggins" }
-    let(:expected_response) do
-      {
-        "data" => {
-          "signup" => nil
-        },
-        "errors" => [
-          {
-            "message" => "Record Invalid",
-            "extensions" => {
-              "status" => 422,
-              "code" => "unprocessable_entity",
-              "detail" => ["Email is invalid"]
-            },
-            "locations" => [
-              {
-                "line" => 2,
-                "column" => 9
-              }
-            ],
-            "path" => ["signup"]
-          }
-        ]
-      }
-    end
 
-    it "returns error" do
-      expect(response).to eq expected_response
+    it_behaves_like "graphql_request", "returns error" do
+      let(:fixture_path) { "json/acceptance/graphql/signup_wrong.json" }
     end
   end
 end

--- a/spec/graphql/mutations/sign_up_spec.rb
+++ b/spec/graphql/mutations/sign_up_spec.rb
@@ -24,7 +24,7 @@ describe Mutations::SignUp do
   context "with valid data" do
     let(:email) { "bilbo.baggins@shire.com" }
 
-    it_behaves_like "graphql_request", "registers a new user" do
+    it_behaves_like "graphql request", "registers a new user" do
       let(:fixture_path) { "json/acceptance/graphql/signup.json" }
       let(:prepared_fixture_file) do
         fixture_file.gsub(
@@ -39,7 +39,7 @@ describe Mutations::SignUp do
   context "with invalid data" do
     let(:email) { "bilbo.baggins" }
 
-    it_behaves_like "graphql_request", "returns error" do
+    it_behaves_like "graphql request", "returns error" do
       let(:fixture_path) { "json/acceptance/graphql/signup_wrong.json" }
     end
   end

--- a/spec/graphql/mutations/update_user_spec.rb
+++ b/spec/graphql/mutations/update_user_spec.rb
@@ -26,7 +26,7 @@ describe Mutations::UpdateUser do
     GRAPHQL
   end
 
-  it_behaves_like "graphql_request", "returns updated user info" do
+  it_behaves_like "graphql request", "returns updated user info" do
     let(:fixture_path) { "json/acceptance/graphql/update_user.json" }
     let(:prepared_fixture_file) do
       fixture_file.gsub(

--- a/spec/graphql/mutations/update_user_spec.rb
+++ b/spec/graphql/mutations/update_user_spec.rb
@@ -2,7 +2,8 @@ require "rails_helper"
 
 describe Mutations::UpdateUser do
   let(:response) { ApplicationSchema.execute(query, execution_context).as_json }
-  let(:execution_context) { { context: { current_user: user } } }
+  let(:execution_context) { { context: schema_context } }
+  let(:schema_context) { { current_user: user } }
   let(:user) { create :user, password: "123456" }
   let(:query) do
     <<-GRAPHQL
@@ -25,23 +26,14 @@ describe Mutations::UpdateUser do
     GRAPHQL
   end
 
-  let(:expected_response) do
-    {
-      "data" => {
-        "updateUser" => {
-          "me" => {
-            "id" => user.id.to_s,
-            "email" => "new_email_11@example.com",
-            "firstName" => "Randle",
-            "lastName" => "McMurphy"
-          }
-        }
-      }
-    }
-  end
-
-  it "returns updated user info" do
-    expect(response).to eq(expected_response)
+  it_behaves_like "graphql_request", "returns updated user info" do
+    let(:fixture_path) { "json/acceptance/graphql/update_user.json" }
+    let(:prepared_fixture_file) do
+      fixture_file.gsub(
+        /:id/,
+        ":id" => user.id
+      )
+    end
   end
 
   it "updates user" do

--- a/spec/graphql/mutations/update_user_spec.rb
+++ b/spec/graphql/mutations/update_user_spec.rb
@@ -1,8 +1,6 @@
 require "rails_helper"
 
 describe Mutations::UpdateUser do
-  let(:response) { ApplicationSchema.execute(query, execution_context).as_json }
-  let(:execution_context) { { context: schema_context } }
   let(:schema_context) { { current_user: user } }
   let(:user) { create :user, password: "123456" }
   let(:query) do
@@ -34,15 +32,5 @@ describe Mutations::UpdateUser do
         ":id" => user.id
       )
     end
-  end
-
-  it "updates user" do
-    response
-
-    expect(user).to have_attributes(
-      email: "new_email_11@example.com",
-      first_name: "Randle",
-      last_name: "McMurphy"
-    )
   end
 end

--- a/spec/graphql/types/query_type_me_spec.rb
+++ b/spec/graphql/types/query_type_me_spec.rb
@@ -17,7 +17,7 @@ describe Types::QueryType do
   end
 
   context "with current_user provided" do
-    it_behaves_like "graphql_request", "gets current_user info" do
+    it_behaves_like "graphql request", "gets current_user info" do
       let(:schema_context) { { current_user: user } }
       let(:fixture_path) { "json/acceptance/graphql/query_type_me.json" }
       let(:prepared_fixture_file) do

--- a/spec/graphql/types/query_type_me_spec.rb
+++ b/spec/graphql/types/query_type_me_spec.rb
@@ -3,12 +3,6 @@ require "rails_helper"
 describe Types::QueryType do
   let!(:user) { create :user }
 
-  let(:response) { ApplicationSchema.execute(query, query_options).as_json }
-
-  let(:query_options) do
-    { context: { current_user: user } }
-  end
-
   let(:query) do
     <<-GRAPHQL
       query {
@@ -22,22 +16,19 @@ describe Types::QueryType do
     GRAPHQL
   end
 
-  let(:expected_response) do
-    {
-      "data" => {
-        "me" => {
-          "id" => user.id.to_s,
-          "email" => user.email,
-          "firstName" => user.first_name,
-          "lastName" => user.last_name
-        }
-      }
-    }
-  end
-
   context "with current_user provided" do
-    it "gets current_user info" do
-      expect(response).to eq expected_response
+    it_behaves_like "graphql_request", "gets current_user info" do
+      let(:schema_context) { { current_user: user } }
+      let(:fixture_path) { "json/acceptance/graphql/query_type_me.json" }
+      let(:prepared_fixture_file) do
+        fixture_file.gsub(
+          /:id|:email|:first_name|:last_name/,
+          ":id" => user.id,
+          ":email" => user.email,
+          ":first_name" => user.first_name,
+          ":last_name" => user.last_name
+        )
+      end
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -8,3 +8,7 @@ require "spec_helper"
 SimpleCov.start "rails"
 
 Dir[Rails.root.join("spec/support/**/*.rb")].sort.each { |f| require f }
+
+RSpec.configure do |config|
+  config.fixture_path = "#{::Rails.root}/spec/fixtures"
+end

--- a/spec/support/shared_examples/graphql_request.rb
+++ b/spec/support/shared_examples/graphql_request.rb
@@ -1,4 +1,4 @@
-shared_examples "graphql_request" do |spec_name|
+shared_examples "graphql request" do |spec_name|
   let(:fixture_file) { File.read(File.join(RSpec.configuration.fixture_path, fixture_path)) }
   let(:parsed_fixture_file) do
     JSON.parse(respond_to?(:prepared_fixture_file) ? prepared_fixture_file : fixture_file)

--- a/spec/support/shared_examples/graphql_request.rb
+++ b/spec/support/shared_examples/graphql_request.rb
@@ -1,0 +1,17 @@
+shared_examples "graphql_request" do |spec_name|
+  let(:fixture_file) { File.read(File.join(RSpec.configuration.fixture_path, fixture_path)) }
+  let(:parsed_fixture_file) do
+    JSON.parse(respond_to?(:prepared_fixture_file) ? prepared_fixture_file : fixture_file)
+  end
+  let(:schema_options) do
+    {
+      context: respond_to?(:schema_context) ? schema_context : {}
+    }
+  end
+
+  let(:response) { ApplicationSchema.execute(query, schema_options).as_json }
+
+  it spec_name do
+    expect(response).to eql(parsed_fixture_file)
+  end
+end


### PR DESCRIPTION
### Summary

This PR moves expected responses to separate JSON-files. Also it adds "graphql request" shared_examples.

### Review notes

While reviewing pull-request (especially when it's your pull-request),
please make sure that:

- you understand what problem is solved by PR and how is it solved
- new tests are in place, no redundant tests
- DB schema changes reflect new migrations
- newly introduced DB fields have indexes and constraints
- there are no missed files (migrations, view templates)
- required ENV variables added and described in `.env.example` and added to Heroku
- associated Heroku review app works correctly with introduced changes

### References
* GitHub Issue #32 
