### PR TITLE
Add user reference to Activity query type

### DIFF
--- a/app/graphql/types/activity_type.rb
+++ b/app/graphql/types/activity_type.rb
@@ -4,5 +4,6 @@ module Types
     field :title, String, null: false
     field :body, String, null: false
     field :created_at, GraphQL::Types::ISO8601DateTime, null: false
+    field :user, Types::UserType, null: false
   end
 end

--- a/spec/fixtures/json/acceptance/graphql/query_type_activities.json
+++ b/spec/fixtures/json/acceptance/graphql/query_type_activities.json
@@ -4,7 +4,13 @@
       "id": ":id",
       "title": "User registered",
       "body": "New user registered with the next attributes: First Name - John, Last Name - Doe",
-      "createdAt": "2020-05-10T12:30:00Z"
+      "createdAt": "2020-05-10T12:30:00Z",
+      "user": {
+        "id": ":user_id",
+        "email": "john.doe@email.me",
+        "firstName": "John",
+        "lastName": "Doe"
+      }
     }]
   }
 }

--- a/spec/graphql/types/query_type_activity_spec.rb
+++ b/spec/graphql/types/query_type_activity_spec.rb
@@ -3,8 +3,10 @@ require "rails_helper"
 describe Types::QueryType do
   include_context "when time is frozen"
 
+  let(:user) { create(:user, email: "john.doe@email.me", first_name: "John", last_name: "Doe") }
   let!(:activity) do
     create(:activity,
+           user: user,
            title: "User registered",
            body: "New user registered with the next attributes: First Name - John, Last Name - Doe")
   end
@@ -16,6 +18,12 @@ describe Types::QueryType do
           title
           body
           createdAt
+          user {
+            id
+            email
+            firstName
+            lastName
+          }
         }
       }
     GRAPHQL
@@ -23,6 +31,6 @@ describe Types::QueryType do
 
   it_behaves_like "graphql request", "gets activities list" do
     let(:fixture_path) { "json/acceptance/graphql/query_type_activities.json" }
-    let(:prepared_fixture_file) { fixture_file.gsub(/:id/, ":id" => activity.id) }
+    let(:prepared_fixture_file) { fixture_file.gsub(/:id|:user_id/, ":id" => activity.id, ":user_id" => user.id) }
   end
 end


### PR DESCRIPTION
### Summary

This PR adds user info for each activity in GraphQL Activities response

### How it works

![Screen Shot 2020-06-15 at 15 27 25](https://user-images.githubusercontent.com/58729845/84657315-c65ab580-af1c-11ea-8773-f4c92ebe8e38.png)

### Test plan

List of steps to manually test introduced functionality:

* Open GraphiQL App
* Make request using schema:
```
query Activities {
  activities {
    id
    title
    body
    createdAt
    user {
      id
      email
      firstName
      lastName
    }
  }
}
```
* Check user related fields in GraphQL response

### Review notes

While reviewing pull-request (especially when it's your pull-request),
please make sure that:

- you understand what problem is solved by PR and how is it solved
- new tests are in place, no redundant tests
- DB schema changes reflect new migrations
- newly introduced DB fields have indexes and constraints
- there are no missed files (migrations, view templates)
- required ENV variables added and described in `.env.example` and added to Heroku
- associated Heroku review app works correctly with introduced changes

### References
* Resolves #52 
