### PR TITLE
Add reset password request activity

### DIFF
--- a/app/graphql/types/activity_event_type.rb
+++ b/app/graphql/types/activity_event_type.rb
@@ -2,5 +2,6 @@ module Types
   class ActivityEventType < Types::BaseEnum
     value "USER LOGGED IN", value: "user_logged_in"
     value "USER REGISTERED", value: "user_registered"
+    value "Reset Password Request", value: "reset_password_request"
   end
 end

--- a/app/graphql/types/activity_event_type.rb
+++ b/app/graphql/types/activity_event_type.rb
@@ -2,6 +2,6 @@ module Types
   class ActivityEventType < Types::BaseEnum
     value "USER LOGGED IN", value: "user_logged_in"
     value "USER REGISTERED", value: "user_registered"
-    value "Reset Password Request", value: "reset_password_request"
+    value "RESET PASSWORD REQUEST", value: "reset_password_request"
   end
 end

--- a/app/graphql/types/activity_event_type.rb
+++ b/app/graphql/types/activity_event_type.rb
@@ -2,7 +2,7 @@ module Types
   class ActivityEventType < Types::BaseEnum
     value "USER LOGGED IN", value: "user_logged_in"
     value "USER REGISTERED", value: "user_registered"
-    value "RESET PASSWORD REQUEST", value: "reset_password_request"
+    value "RESET_PASSWORD_REQUESTED", value: "reset_password_requested"
     value "USER UPDATED", value: "user_updated"
   end
 end

--- a/app/interactors/request_password_reset.rb
+++ b/app/interactors/request_password_reset.rb
@@ -10,7 +10,7 @@ class RequestPasswordReset
 
   after do
     ApplicationMailer.password_recovery(user).deliver_later
-    RegisterActivityJob.perform_later(user.id, :reset_password_request)
+    RegisterActivityJob.perform_later(user.id, :reset_password_requested)
   end
 
   private

--- a/app/interactors/request_password_reset.rb
+++ b/app/interactors/request_password_reset.rb
@@ -10,6 +10,7 @@ class RequestPasswordReset
 
   after do
     ApplicationMailer.password_recovery(user).deliver_later
+    RegisterActivityJob.perform_later(user.id, :reset_password_request)
   end
 
   private

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -3,7 +3,7 @@ class Activity < ApplicationRecord
 
   belongs_to :user
 
-  enumerize :event, in: %i[user_registered user_updated reset_password_request]
+  enumerize :event, in: %i[user_registered user_updated reset_password_requested]
 
   validates :title, :body, presence: true
 end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -3,7 +3,7 @@ class Activity < ApplicationRecord
 
   belongs_to :user
 
-  enumerize :event, in: %w[user_registered]
+  enumerize :event, in: %w[user_registered reset_password_request]
 
   validates :title, :body, presence: true
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -35,4 +35,4 @@ en:
     user_updated: "User updated with the next attributes:\n First name - %{first_name},\n Last name - %{last_name},\n Email - %{email}\n"
     user_logged_in: "User logged in with the next attributes:\n First name - %{first_name},\n Last name - %{last_name}\n"
     user_registered: "New user registered with the next attributes:\n First name - %{first_name},\n Last name - %{last_name}\n"
-    reset_password_request: "User send reset password request"
+    reset_password_requested: "User requested reset password instructions"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,3 +34,4 @@ en:
   activity:
     user_logged_in: "User logged in with the next attributes:\n First name - %{first_name},\n Last name - %{last_name}\n"
     user_registered: "New user registered with the next attributes:\n First name - %{first_name},\n Last name - %{last_name}\n"
+    reset_password_request: "User send reset password request"

--- a/spec/interactors/request_password_reset_spec.rb
+++ b/spec/interactors/request_password_reset_spec.rb
@@ -12,6 +12,8 @@ describe RequestPasswordReset do
 
   context "when user exists" do
     let(:user) { create :user }
+    let(:user_id) { user.id }
+    let(:event) { :reset_password_request }
 
     it_behaves_like "success interactor"
 
@@ -19,6 +21,8 @@ describe RequestPasswordReset do
       expect(ApplicationMailer).to receive(:password_recovery)
       interactor.run
     end
+
+    it_behaves_like "activity source"
   end
 
   context "when user doesn't exist" do

--- a/spec/interactors/request_password_reset_spec.rb
+++ b/spec/interactors/request_password_reset_spec.rb
@@ -13,7 +13,7 @@ describe RequestPasswordReset do
   context "when user exists" do
     let(:user) { create :user }
     let(:user_id) { user.id }
-    let(:event) { :reset_password_request }
+    let(:event) { :reset_password_requested }
 
     it_behaves_like "success interactor"
 


### PR DESCRIPTION
### Summary

User should see request reset password activity

### How it works

Screenshots/screencasts of the pull request introduced functionality.

### Test plan

List of steps to manually test introduced functionality:

* Open GraphiQL App
* Make request using schema:
```
me {
  id
  email
  activities {
    id
    title
    body
    event
    createdAt
  }
}
```
*  Check that response contents activity with event "RESET PASSWORD REQUEST"

### Review notes

While reviewing pull-request (especially when it's your pull-request),
please make sure that:

- you understand what problem is solved by PR and how is it solved
- new tests are in place, no redundant tests
- DB schema changes reflect new migrations
- newly introduced DB fields have indexes and constraints
- there are no missed files (migrations, view templates)
- required ENV variables added and described in `.env.example` and added to Heroku
- associated Heroku review app works correctly with introduced changes

### Deploy notes

Notes regarding deployment the contained body of work.
These should note any db migrations, ENV variables, services, scripts, etc.

### References
* Resolves #69  Issue

