### PR TITLE
Add user reset password activity

### DIFF
--- a/app/graphql/types/activity_event_type.rb
+++ b/app/graphql/types/activity_event_type.rb
@@ -2,6 +2,6 @@ module Types
   class ActivityEventType < Types::BaseEnum
     value "USER LOGGED IN", value: "user_logged_in"
     value "USER REGISTERED", value: "user_registered"
-    value "USER UPDATED PASSWORD", value: "user_updated_password"
+    value "USER UPDATED PASSWORD", value: "user_reset_password"
   end
 end

--- a/app/graphql/types/activity_event_type.rb
+++ b/app/graphql/types/activity_event_type.rb
@@ -2,6 +2,6 @@ module Types
   class ActivityEventType < Types::BaseEnum
     value "USER LOGGED IN", value: "user_logged_in"
     value "USER REGISTERED", value: "user_registered"
-    value "USER UPDATED PASSWORD", value: "user_reset_password"
+    value "USER RESET PASSWORD", value: "user_reset_password"
   end
 end

--- a/app/graphql/types/activity_event_type.rb
+++ b/app/graphql/types/activity_event_type.rb
@@ -2,5 +2,6 @@ module Types
   class ActivityEventType < Types::BaseEnum
     value "USER LOGGED IN", value: "user_logged_in"
     value "USER REGISTERED", value: "user_registered"
+    value "USER UPDATED PASSWORD", value: "user_updated_password"
   end
 end

--- a/app/interactors/update_password.rb
+++ b/app/interactors/update_password.rb
@@ -10,6 +10,6 @@ class UpdatePassword
            CreateRefreshToken
 
   after do
-    RegisterActivityJob.perform_later(user.id, :user_updated_password)
+    RegisterActivityJob.perform_later(user.id, :user_reset_password)
   end
 end

--- a/app/interactors/update_password.rb
+++ b/app/interactors/update_password.rb
@@ -2,8 +2,14 @@ class UpdatePassword
   include Interactor::Organizer
   include TransactionalInteractor
 
+  delegate :user, to: :context
+
   organize FindUserByToken,
            UpdateUserPassword,
            CreateAccessToken,
            CreateRefreshToken
+
+  after do
+    RegisterActivityJob.perform_later(user.id, :user_updated_password)
+  end
 end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -3,7 +3,7 @@ class Activity < ApplicationRecord
 
   belongs_to :user
 
-  enumerize :event, in: %w[user_registered]
+  enumerize :event, in: %w[user_registered user_updated_password]
 
   validates :title, :body, presence: true
 end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -3,7 +3,7 @@ class Activity < ApplicationRecord
 
   belongs_to :user
 
-  enumerize :event, in: %w[user_registered user_updated_password]
+  enumerize :event, in: %w[user_registered user_reset_password]
 
   validates :title, :body, presence: true
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,3 +34,4 @@ en:
   activity:
     user_logged_in: "User logged in with the next attributes:\n First name - %{first_name},\n Last name - %{last_name}\n"
     user_registered: "New user registered with the next attributes:\n First name - %{first_name},\n Last name - %{last_name}\n"
+    user_updated_password: "User updated password"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,4 +34,4 @@ en:
   activity:
     user_logged_in: "User logged in with the next attributes:\n First name - %{first_name},\n Last name - %{last_name}\n"
     user_registered: "New user registered with the next attributes:\n First name - %{first_name},\n Last name - %{last_name}\n"
-    user_updated_password: "User updated password"
+    user_reset_password: "User reset password"

--- a/spec/interactors/update_password_spec.rb
+++ b/spec/interactors/update_password_spec.rb
@@ -9,7 +9,7 @@ describe UpdatePassword do
   context "when token valid" do
     let(:reset_token) { user.password_reset_token }
     let(:user_id) { user.id }
-    let(:event) { :user_updated_password }
+    let(:event) { :user_reset_password }
 
     it_behaves_like "success interactor"
 

--- a/spec/interactors/update_password_spec.rb
+++ b/spec/interactors/update_password_spec.rb
@@ -8,6 +8,8 @@ describe UpdatePassword do
 
   context "when token valid" do
     let(:reset_token) { user.password_reset_token }
+    let(:user_id) { user.id }
+    let(:event) { :user_updated_password }
 
     it_behaves_like "success interactor"
 
@@ -19,6 +21,8 @@ describe UpdatePassword do
         password_reset_sent_at: nil
       )
     end
+
+    it_behaves_like "activity source"
   end
 
   context "when token is wrong" do


### PR DESCRIPTION
### Summary

User should see reset password activity

### How it works

Screenshots/screencasts of the pull request introduced functionality.

### Test plan

List of steps to manually test introduced functionality:

* Open GraphiQL App
* Make request using schema:
```
me {
  id
  email
  activities {
    id
    title
    body
    event
    createdAt
  }
}
```
* Check that response contents activity with event "USER UPDATED PASSWORD"

### Review notes

While reviewing pull-request (especially when it's your pull-request),
please make sure that:

- you understand what problem is solved by PR and how is it solved
- new tests are in place, no redundant tests
- DB schema changes reflect new migrations
- newly introduced DB fields have indexes and constraints
- there are no missed files (migrations, view templates)
- required ENV variables added and described in `.env.example` and added to Heroku
- associated Heroku review app works correctly with introduced changes

### Deploy notes

Notes regarding deployment the contained body of work.
These should note any db migrations, ENV variables, services, scripts, etc.

### References
* Resolves #71 Issue
