### PR TITLE
Bearer authentication schema

### DIFF
--- a/app/controllers/concerns/authenticable_user.rb
+++ b/app/controllers/concerns/authenticable_user.rb
@@ -9,11 +9,11 @@ module AuthenticableUser
   end
 
   def authorization_header
-    @authorization_header ||= request.headers["Authorization"].to_s.split(" ")
+    Hash[*request.headers["Authorization"].to_s.split(" ")]
   end
 
   def token
-    @token ||= authorization_header.last if authorization_header.first == "Bearer"
+    @token ||= authorization_header["Bearer"]
   end
 
   def payload

--- a/app/controllers/concerns/authenticable_user.rb
+++ b/app/controllers/concerns/authenticable_user.rb
@@ -8,12 +8,8 @@ module AuthenticableUser
     User.find_by(id: payload["sub"])
   end
 
-  def authorization_header
-    Hash[*request.headers["Authorization"].to_s.split(" ")]
-  end
-
   def token
-    @token ||= authorization_header["Bearer"]
+    @token ||= request.headers["Authorization"].to_s.match(/Bearer (.*)/).to_a.last
   end
 
   def payload

--- a/app/controllers/concerns/authenticable_user.rb
+++ b/app/controllers/concerns/authenticable_user.rb
@@ -8,8 +8,12 @@ module AuthenticableUser
     User.find_by(id: payload["sub"])
   end
 
+  def authorization_header
+    @authorization_header ||= request.headers["Authorization"].to_s.split(" ")
+  end
+
   def token
-    @token ||= request.headers["Authorization"].to_s.split(" ").last
+    @token ||= authorization_header.last if authorization_header.first == "Bearer"
   end
 
   def payload

--- a/spec/acceptance/authentication_user_spec.rb
+++ b/spec/acceptance/authentication_user_spec.rb
@@ -14,7 +14,7 @@ describe "Authenticate user", type: :request do
   end
 
   before do
-    post "/graphql", headers: { authorization: refresh_token.token }, params: { query: query }
+    post "/graphql", headers: { authorization: "Bearer #{refresh_token.token}" }, params: { query: query }
   end
 
   context "with valid token" do


### PR DESCRIPTION
### Summary

At the moment we accept Authorization header without schema. So, Authotrization: <token> and Authorization: Bearer <token> both valid. We should accept only Bearer schema.

### How it works

Screenshots/screencasts of the pull request introduced functionality.

### Test plan

List of steps to manually test introduced functionality:

* Open GraphiQL App
* Make request using schema:
```
  query {
    me: {
      id
      name
    }
  }
```
* ...

### Review notes

While reviewing pull-request (especially when it's your pull-request),
please make sure that:

- you understand what problem is solved by PR and how is it solved
- new tests are in place, no redundant tests
- DB schema changes reflect new migrations
- newly introduced DB fields have indexes and constraints
- there are no missed files (migrations, view templates)
- required ENV variables added and described in `.env.example` and added to Heroku
- associated Heroku review app works correctly with introduced changes

### Deploy notes

Notes regarding deployment the contained body of work.
These should note any db migrations, ENV variables, services, scripts, etc.

### References
* Resolves #96  Issue