### PR TITLE
Add pseudo-tty to docker config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,8 @@ services:
       - net.core.somaxconn=511
   app:
     <<: *app_base
+    stdin_open: true
+    tty: true
     depends_on:
       - mailcatcher
     ports:


### PR DESCRIPTION
### Summary

This PR adds pseudo-tty to `docker-compose` config so we can use `byebug` for debugging purposes

### References
* Resolves #122 