### PR TITLE
Add Action Policy

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem "pg"
 gem "rails", "~> 6.0.3.5"
 
 # all other gems
+gem "action_policy-graphql"
 gem "aws-sdk-s3"
 gem "bcrypt"
 gem "bootsnap", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -155,7 +155,9 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
-    mimemagic (0.3.5)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     minitest (5.14.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,12 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    action_policy (0.5.5)
+      ruby-next-core (>= 0.11.0)
+    action_policy-graphql (0.5.2)
+      action_policy (>= 0.5.0)
+      graphql (>= 1.9.3)
+      ruby-next-core (>= 0.10.0)
     actioncable (6.0.3.5)
       actionpack (= 6.0.3.5)
       nio4r (~> 2.0)
@@ -240,6 +246,7 @@ GEM
       rubocop (>= 0.72.0)
     rubocop-rspec (1.38.1)
       rubocop (>= 0.68.1)
+    ruby-next-core (0.12.0)
     ruby-progressbar (1.10.1)
     shrine (3.3.0)
       content_disposition (~> 1.0)
@@ -280,6 +287,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  action_policy-graphql
   aws-sdk-s3
   bcrypt
   bootsnap
@@ -304,7 +312,7 @@ DEPENDENCIES
   pg
   puma
   rack-cors
-  rails (~> 6.0.3.4)
+  rails (~> 6.0.3.5)
   rspec-rails
   rubocop
   rubocop-rails

--- a/app/graphql/resolvers/activities.rb
+++ b/app/graphql/resolvers/activities.rb
@@ -9,7 +9,7 @@ module Resolvers
     end
 
     def raw_relation
-      object ? Activity.where(user_id: object.id) : Activity.all
+      authorized_scope(Activity.all, with: ::ActivityPolicy)
     end
   end
 end

--- a/app/graphql/resolvers/base.rb
+++ b/app/graphql/resolvers/base.rb
@@ -1,5 +1,7 @@
 module Resolvers
   class Base < GraphQL::Schema::Resolver
+    include ActionPolicy::GraphQL::Behaviour
+
     argument_class Types::BaseArgument
 
     def resolve(**options)

--- a/app/graphql/types/base_object.rb
+++ b/app/graphql/types/base_object.rb
@@ -1,5 +1,7 @@
 module Types
   class BaseObject < GraphQL::Schema::Object
+    include ActionPolicy::GraphQL::Behaviour
+
     field_class Types::BaseField
   end
 end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -6,5 +6,7 @@ class Activity < ApplicationRecord
   enumerize :event, in: %i[user_registered user_logged_in user_updated reset_password_requested
                            user_reset_password]
 
+  scope :public_events, -> { where(event: %i[user_registered user_logged_in]) }
+
   validates :title, :body, presence: true
 end

--- a/app/policies/activity_policy.rb
+++ b/app/policies/activity_policy.rb
@@ -1,4 +1,6 @@
 class ActivityPolicy < ApplicationPolicy
+  authorize :user, allow_nil: true
+
   relation_scope do |relation|
     next relation.public_events unless user
 

--- a/app/policies/activity_policy.rb
+++ b/app/policies/activity_policy.rb
@@ -1,0 +1,7 @@
+class ActivityPolicy < ApplicationPolicy
+  relation_scope do |relation|
+    next relation.public_events unless user
+
+    relation.public_events.or(relation.where(user: user))
+  end
+end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,0 +1,7 @@
+class ApplicationPolicy < ActionPolicy::Base
+  private
+
+   def owner?
+     record.user_id == user.id
+   end
+end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,7 +1,2 @@
 class ApplicationPolicy < ActionPolicy::Base
-  private
-
-   def owner?
-     record.user_id == user.id
-   end
 end

--- a/spec/factories/activities.rb
+++ b/spec/factories/activities.rb
@@ -4,5 +4,13 @@ FactoryBot.define do
     body { "New user registered." }
     event { :user_registered }
     user
+
+    trait :public do
+      event { :user_registered }
+    end
+
+    trait :private do
+      event { :user_updated }
+    end
   end
 end

--- a/spec/fixtures/json/acceptance/graphql/authorized_query_type_activities.json
+++ b/spec/fixtures/json/acceptance/graphql/authorized_query_type_activities.json
@@ -1,0 +1,76 @@
+{
+  "data": {
+    "activities": {
+      "edges": [{
+        "cursor": "MQ",
+        "node": {
+          "id": ":id_1",
+          "title": "User registered",
+          "event": "USER_REGISTERED",
+          "body": "New user registered with the next attributes: First Name - John, Last Name - Doe",
+          "createdAt": "2020-05-10T12:30:00Z",
+          "user": {
+            "id": ":user_id",
+            "email": ":email",
+            "firstName": ":first_name",
+            "lastName": ":last_name"
+          }
+        }
+      },
+      {
+        "cursor": "Mg",
+        "node": {
+          "id": ":id_2",
+          "title": "User Logged in",
+          "event": "USER_LOGGED_IN",
+          "body": "User logged in",
+          "createdAt": "2020-05-10T12:30:00Z",
+          "user": {
+            "id": ":user_id",
+            "email": ":email",
+            "firstName": ":first_name",
+            "lastName": ":last_name"
+          }
+        }
+      },
+      {
+        "cursor": "Mw",
+        "node": {
+          "id": ":id_3",
+          "title": "User Logged in",
+          "event": "USER_LOGGED_IN",
+          "body": "User logged in",
+          "createdAt": "2020-05-10T12:30:00Z",
+          "user": {
+            "id": ":user_id",
+            "email": ":email",
+            "firstName": ":first_name",
+            "lastName": ":last_name"
+          }
+        }
+      },
+      {
+        "cursor": "NA",
+        "node": {
+          "id": ":id_4",
+          "title": "User updated",
+          "event": "USER_UPDATED",
+          "body": "New user updated with the next attributes: First Name - John, Last Name - Doe",
+          "createdAt": "2020-05-10T12:30:00Z",
+          "user": {
+            "id": ":user_id",
+            "email": ":email",
+            "firstName": ":first_name",
+            "lastName": ":last_name"
+          }
+        }
+      }],
+      "pageInfo": {
+        "endCursor": "NA",
+        "hasNextPage": false,
+        "hasPreviousPage": false,
+        "startCursor": "MQ"
+      }
+    }
+  }
+}

--- a/spec/fixtures/json/acceptance/graphql/second_page_query_type_activities.json
+++ b/spec/fixtures/json/acceptance/graphql/second_page_query_type_activities.json
@@ -5,9 +5,9 @@
         "cursor": "Mg",
         "node": {
           "id": ":first_id",
-          "title": "User Updated",
-          "event": "USER_UPDATED",
-          "body": "New user updated with the next attributes: First Name - John, Last Name - Doe",
+          "title": "User Logged in",
+          "event": "USER_LOGGED_IN",
+          "body": "User logged in",
           "createdAt": "2020-05-10T12:30:00Z",
           "user": {
             "id": ":user_id",
@@ -21,9 +21,9 @@
         "cursor": "Mw",
         "node": {
           "id": ":second_id",
-          "title": "User Updated",
-          "event": "USER_UPDATED",
-          "body": "New user updated with the next attributes: First Name - John, Last Name - Doe",
+          "title": "User Logged in",
+          "event": "USER_LOGGED_IN",
+          "body": "User logged in",
           "createdAt": "2020-05-10T12:30:00Z",
           "user": {
             "id": ":user_id",

--- a/spec/graphql/types/query_type_activity_spec.rb
+++ b/spec/graphql/types/query_type_activity_spec.rb
@@ -117,7 +117,7 @@ describe Types::QueryType do
   end
 
   context "with authorized user" do
-    let!(:user) { create :user, :with_data }
+    let!(:user) { create(:user, :with_data) }
     let(:token_payload) { { type: "access" } }
 
     it_behaves_like "graphql request", "includes user private activities to result" do

--- a/spec/graphql/types/query_type_activity_spec.rb
+++ b/spec/graphql/types/query_type_activity_spec.rb
@@ -14,14 +14,21 @@ describe Types::QueryType do
   let!(:activity_2) do
     create(:activity,
            user: user,
-           title: "User Updated",
-           body: "New user updated with the next attributes: First Name - John, Last Name - Doe",
-           event: :user_updated)
+           title: "User Logged in",
+           body: "User logged in",
+           event: :user_logged_in)
   end
   let!(:activity_3) do
     create(:activity,
            user: user,
-           title: "User Updated",
+           title: "User Logged in",
+           body: "User logged in",
+           event: :user_logged_in)
+  end
+  let!(:private_activity) do
+    create(:activity,
+           user: user,
+           title: "User updated",
            body: "New user updated with the next attributes: First Name - John, Last Name - Doe",
            event: :user_updated)
   end
@@ -105,6 +112,59 @@ describe Types::QueryType do
           ":second_id" => activity_3.id,
           ":user_id" => user.id
         )
+      end
+    end
+  end
+
+  context "with authorized user" do
+    let!(:user) { create :user, :with_data }
+    let(:token_payload) { { type: "access" } }
+
+    it_behaves_like "graphql request", "includes user private activities to result" do
+      let(:schema_context) { { current_user: user, token_payload: token_payload.stringify_keys } }
+      let(:fixture_path) { "json/acceptance/graphql/authorized_query_type_activities.json" }
+      let(:prepared_fixture_file) do
+        fixture_file.gsub(
+          /:id_1|:id_2|:id_3|:id_4|:user_id|:email|:first_name|:last_name/,
+          ":id_1" => activity.id,
+          ":id_2" => activity_2.id,
+          ":id_3" => activity_3.id,
+          ":id_4" => private_activity.id,
+          ":user_id" => user.id,
+          ":email" => user.email,
+          ":first_name" => user.first_name,
+          ":last_name" => user.last_name
+        )
+      end
+      let(:query) do
+        <<-GRAPHQL
+          query {
+            activities {
+              edges {
+                cursor
+                node {
+                  id
+                  title
+                  body
+                  event
+                  createdAt
+                  user {
+                    id
+                    email
+                    firstName
+                    lastName
+                  }
+                }
+              }
+              pageInfo {
+                endCursor
+                startCursor
+                hasPreviousPage
+                hasNextPage
+              }
+            }
+          }
+        GRAPHQL
       end
     end
   end

--- a/spec/policies/activity_policy_spec.rb
+++ b/spec/policies/activity_policy_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+describe ActivityPolicy do
+  subject(:policy) { described_class.new(user: current_user) }
+
+  describe "#relation_scope" do
+    subject(:relation_scope) { policy.authorized_scope(Activity.all) }
+
+    let!(:own_private_event) { create(:activity, :private, user: user) }
+    let!(:public_event) { create(:activity, :public) }
+    let(:user) { create(:user) }
+    let(:current_user) { user }
+
+    before { create(:activity, :private) }
+
+    it "returns user events" do
+      expect(relation_scope).to match_array([own_private_event, public_event])
+    end
+
+    context "when user is not defined" do
+      let(:current_user) { nil }
+
+      it "returns only public events" do
+        expect(relation_scope).to match_array([public_event])
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Summary

This PR adds `action_policy-graphql` gem and specifies `relation_scope` for `ActivityPolicy`: private activities are available for owner only, public activities are available for everybody.

### How it works

Screenshots/screencasts of the pull request introduced functionality.

### Test plan

List of steps to manually test introduced functionality:

* Open GraphiQL App
* Make request using schema:
```
query {
  activities {
    edges {
      cursor
        node {
        id
        title
        event
      }
    }
  }
}
```
* ...

### Review notes

While reviewing pull-request (especially when it's your pull-request),
please make sure that:

- you understand what problem is solved by PR and how is it solved
- new tests are in place, no redundant tests
- DB schema changes reflect new migrations
- newly introduced DB fields have indexes and constraints
- there are no missed files (migrations, view templates)
- required ENV variables added and described in `.env.example` and added to Heroku
- associated Heroku review app works correctly with introduced changes

### Deploy notes

Notes regarding deployment the contained body of work.
These should note any db migrations, ENV variables, services, scripts, etc.

### References
* Resolves #99  Issue
