### PR TITLE
Fix Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -304,7 +304,7 @@ DEPENDENCIES
   pg
   puma
   rack-cors
-  rails (~> 6.0.3.4)
+  rails (~> 6.0.3.5)
   rspec-rails
   rubocop
   rubocop-rails


### PR DESCRIPTION
### Summary

It follows up to #133 - somehow Rails version in `Gemfile.lock` wasn't updated. This PR fixes that.
