### PR TITLE
Add GraphQL::Execution::Errors module

### DIFF
--- a/app/graphql/application_schema.rb
+++ b/app/graphql/application_schema.rb
@@ -8,4 +8,10 @@ class ApplicationSchema < GraphQL::Schema
   use GraphQL::Pagination::Connections
   use GraphQL::Analysis::AST
   use GraphQL::Batch
+  use GraphQL::Execution::Errors
+
+  rescue_from(ActiveRecord::RecordNotFound) do |_err, _obj, _args, _ctx, field|
+    raise GraphQL::ExecutionError.new("#{field.type.unwrap.graphql_name} not found",
+                                      extensions: { message: "Not Found", status: 404, code: :not_found })
+  end
 end


### PR DESCRIPTION
### Summary

@ArthurZaharov suggested to implement these `GraphQL::Execution::Errors` module in order to be able to handle errors.


### How it works

We can handle errors with `rescue_from` method. For example, for `ActiveRecord::RecordNotFound`:
```ruby
rescue_from(ActiveRecord::RecordNotFound) do |_err, _obj, _args, _ctx, field|
    raise GraphQL::ExecutionError.new("#{field.type.unwrap.graphql_name} not found",
                                      extensions: { message: "Not Found", status: 404, code: :not_found })
  end
```
### Test plan

N/A


### Review notes

While reviewing pull-request (especially when it's your pull-request),
please make sure that:

- you understand what problem is solved by PR and how is it solved
- new tests are in place, no redundant tests
- DB schema changes reflect new migrations
- newly introduced DB fields have indexes and constraints
- there are no missed files (migrations, view templates)
- required ENV variables added and described in `.env.example` and added to Heroku
- associated Heroku review app works correctly with introduced changes

### Deploy notes

N/A

### References
N/A
