### PR TITLE
Changes to the names of the required headers in the `presignData` mutation response

### DIFF
--- a/app/interactors/prepare_presign_image.rb
+++ b/app/interactors/prepare_presign_image.rb
@@ -36,8 +36,8 @@ class PreparePresignImage
 
   def options
     {
-      content_disposition: ContentDisposition.inline(filename),
-      content_type: type,
+      "Content-Disposition": ContentDisposition.inline(filename),
+      "Content-Type": type,
       content_length_range: 0..UPLOAD_SIZE_LIMIT
     }
   end

--- a/spec/acceptance/image_uploading_spec.rb
+++ b/spec/acceptance/image_uploading_spec.rb
@@ -7,8 +7,8 @@ describe "Upload image", type: :request do
   let(:params) do
     {
       key: "#{storage_key}/#{file_key}",
-      content_disposition: "inline; filename='avatar.png'; filename*=UTF-8''avatar.png",
-      content_type: "image/png",
+      "Content-Disposition": "inline; filename='avatar.png'; filename*=UTF-8''avatar.png",
+      "Content-Type": "image/png",
       content_length_range: "0..10485760",
       file: fixture_file_upload(avatar_image_path, "image/png")
     }


### PR DESCRIPTION
### Summary

@ArthurZaharov noticed that some headers from `presignData` mutation are not properly set from a specification point of view.

### How it works

In order to upload presigned file, you have to use `Content-Disposition` and `Content-Type` headers instead of `content_disposition` and `content_type` respectively.

### Test plan

N/A

### Review notes

While reviewing pull-request (especially when it's your pull-request),
please make sure that:

- you understand what problem is solved by PR and how is it solved
- new tests are in place, no redundant tests
- DB schema changes reflect new migrations
- newly introduced DB fields have indexes and constraints
- there are no missed files (migrations, view templates)
- required ENV variables added and described in `.env.example` and added to Heroku
- associated Heroku review app works correctly with introduced changes

### Deploy notes

N/A

### References
N/A
