### PR TITLE
Update graphql-ruby to 1.12.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,7 +122,7 @@ GEM
     ffi (1.12.2)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
-    graphql (1.10.6)
+    graphql (1.12.6)
     graphql-batch (0.4.3)
       graphql (>= 1.3, < 2)
       promise.rb (~> 0.7.2)


### PR DESCRIPTION
### Summary

According [this lecture](https://youtu.be/yz55e2zC5vk?t=585) by Dmitry Tsepelev version 1.12.6 requires less memory than 1.11.x and works faster. We're still using 1.10.6. This PR updates `graphql-ruby` to the specified version.

