### PR TITLE
Add validation to image uploader

### DIFF
--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -1,4 +1,12 @@
 class ImageUploader < Shrine
+  ALLOWED_EXTENSIONS = %w[jpg jpeg png webp].freeze
+  ALLOWED_MIME_TYPES = %w[image/jpeg image/png image/webp].freeze
+
+  Attacher.validate do
+    validate_mime_type ALLOWED_MIME_TYPES
+    validate_extension ALLOWED_EXTENSIONS
+  end
+
   def generate_location(io, record: nil, derivative: nil, **options)
     options[:key]&.split("/")&.last || super
   end

--- a/spec/fixtures/files/fake_image.png
+++ b/spec/fixtures/files/fake_image.png
@@ -1,0 +1,1 @@
+fake image file

--- a/spec/fixtures/files/test.txt
+++ b/spec/fixtures/files/test.txt
@@ -1,0 +1,1 @@
+text test file

--- a/spec/fixtures/json/acceptance/graphql/signup_wrong_file.json
+++ b/spec/fixtures/json/acceptance/graphql/signup_wrong_file.json
@@ -1,0 +1,19 @@
+{
+  "data": {
+    "signup": null
+  },
+  "errors": [
+    {
+      "message": "Record Invalid",
+      "extensions": {
+        "status": 422,
+        "code": "unprocessable_entity",
+        "detail": ["Email is invalid"]
+      },
+      "locations": [
+        { "line": 2, "column": 9 }
+      ],
+      "path": ["signup"]
+    }
+  ]
+}

--- a/spec/graphql/mutations/sign_up_spec.rb
+++ b/spec/graphql/mutations/sign_up_spec.rb
@@ -66,4 +66,12 @@ describe Mutations::SignUp do
       let(:fixture_path) { "json/acceptance/graphql/signup_wrong.json" }
     end
   end
+
+  context "with invalid avatar" do
+    let(:avatar_image_path) { Rails.root.join("spec/fixtures/files/text.txt") }
+
+    it_behaves_like "graphql request", "returns error" do
+      let(:fixture_path) { "json/acceptance/graphql/signup_wrong_file.json" }
+    end
+  end
 end

--- a/spec/graphql/mutations/sign_up_spec.rb
+++ b/spec/graphql/mutations/sign_up_spec.rb
@@ -66,12 +66,4 @@ describe Mutations::SignUp do
       let(:fixture_path) { "json/acceptance/graphql/signup_wrong.json" }
     end
   end
-
-  context "with invalid avatar" do
-    let(:avatar_image_path) { Rails.root.join("spec/fixtures/files/text.txt") }
-
-    it_behaves_like "graphql request", "returns error" do
-      let(:fixture_path) { "json/acceptance/graphql/signup_wrong_file.json" }
-    end
-  end
 end

--- a/spec/uploaders/image_uploader_spec.rb
+++ b/spec/uploaders/image_uploader_spec.rb
@@ -1,0 +1,55 @@
+require "rails_helper"
+
+describe ImageUploader do
+  let(:user) { build(:user) }
+
+  before do
+    user.avatar = File.open(Rails.root.join(image_path), "rb")
+    user.save
+  end
+
+  context "with valid data" do
+    let(:image_path) { "spec/fixtures/images/avatar.jpg" }
+    let(:avatar) { user.avatar }
+
+    it "saves avatar data" do
+      expect(user).to be_persisted
+      expect(avatar.mime_type).to eq("image/jpeg")
+      expect(avatar.extension).to eq("jpg")
+      expect(avatar.size).to be_instance_of(Integer)
+    end
+  end
+
+  context "with wrong extension and mime type" do
+    let(:image_path) { "spec/fixtures/files/test.txt" }
+    let(:error_messages) do
+      {
+        avatar: [
+          "type must be one of: image/jpeg, image/png, image/webp, image/tiff",
+          "extension must be one of: jpg, jpeg, png, webp"
+        ]
+      }
+    end
+
+    it "raises error" do
+      expect(user).not_to be_persisted
+      expect(user.errors.messages).to eq(error_messages)
+    end
+  end
+
+  context "with wrong mime type" do
+    let(:image_path) { "spec/fixtures/files/fake_image.png" }
+    let(:error_messages) do
+      {
+        avatar: [
+          "type must be one of: image/jpeg, image/png, image/webp, image/tiff"
+        ]
+      }
+    end
+
+    it "raises error" do
+      expect(user).not_to be_persisted
+      expect(user.errors.messages).to eq(error_messages)
+    end
+  end
+end

--- a/spec/uploaders/image_uploader_spec.rb
+++ b/spec/uploaders/image_uploader_spec.rb
@@ -25,7 +25,7 @@ describe ImageUploader do
     let(:error_messages) do
       {
         avatar: [
-          "type must be one of: image/jpeg, image/png, image/webp, image/tiff",
+          "type must be one of: image/jpeg, image/png, image/webp",
           "extension must be one of: jpg, jpeg, png, webp"
         ]
       }
@@ -42,7 +42,7 @@ describe ImageUploader do
     let(:error_messages) do
       {
         avatar: [
-          "type must be one of: image/jpeg, image/png, image/webp, image/tiff"
+          "type must be one of: image/jpeg, image/png, image/webp"
         ]
       }
     end


### PR DESCRIPTION
### Summary

This PR adds validation to `ImageUploader` by extension and mime type

### How it works

Screenshots/screencasts of the pull request introduced functionality.

### Test plan

List of steps to manually test introduced functionality:

* Open GraphiQL App
* Make request using schema:
```
  query {
    me: {
      id
      name
    }
  }
```
* ...

### Review notes

While reviewing pull-request (especially when it's your pull-request),
please make sure that:

- you understand what problem is solved by PR and how is it solved
- new tests are in place, no redundant tests
- DB schema changes reflect new migrations
- newly introduced DB fields have indexes and constraints
- there are no missed files (migrations, view templates)
- required ENV variables added and described in `.env.example` and added to Heroku
- associated Heroku review app works correctly with introduced changes

### Deploy notes

Notes regarding deployment the contained body of work.
These should note any db migrations, ENV variables, services, scripts, etc.

### References
* Resolves #138 
* [GitHub Pull Request ####](https://github.com/fs/rails-base-graphql-api/pull/####)
