### PR TITLE
Implement input field to confirmUser mutation

### DIFF
--- a/app/graphql/mutations/confirm_user.rb
+++ b/app/graphql/mutations/confirm_user.rb
@@ -1,11 +1,11 @@
 module Mutations
   class ConfirmUser < BaseMutation
-    argument :value, String, required: true
+    argument :input, Types::ConfirmUserInput, required: true
 
     type Types::CurrentUserType
 
-    def resolve(options)
-      result = ::ConfirmUser.call(options)
+    def resolve(input:)
+      result = ::ConfirmUser.call(value: input.value)
 
       if result.success?
         result.user

--- a/app/graphql/types/confirm_user_input.rb
+++ b/app/graphql/types/confirm_user_input.rb
@@ -1,0 +1,5 @@
+module Types
+  class ConfirmUserInput < Types::BaseInputObject
+    argument :value, String, required: true
+  end
+end

--- a/spec/graphql/mutations/confirm_user_spec.rb
+++ b/spec/graphql/mutations/confirm_user_spec.rb
@@ -11,7 +11,9 @@ describe Mutations::ConfirmUser do
     <<-GRAPHQL
       mutation {
         confirmUser (
-          value: "#{possession_token.value}"
+          input: {
+            value: "#{possession_token.value}"
+          }
         ) {
           id
           confirmedAt


### PR DESCRIPTION
### Summary

`input` field has been added to `confirmUser` mutation.

### How it works

N/A

### Test plan

List of steps to manually test introduced functionality:

* Open GraphiQL App
* Make request using schema:
```graphql
mutation {
  confirmUser (
    input: {
      value: <String>
    }
    ) {
       id
       confirmedAt
    }
}
```

### Review notes

While reviewing pull-request (especially when it's your pull-request),
please make sure that:

- you understand what problem is solved by PR and how is it solved
- new tests are in place, no redundant tests
- DB schema changes reflect new migrations
- newly introduced DB fields have indexes and constraints
- there are no missed files (migrations, view templates)
- required ENV variables added and described in `.env.example` and added to Heroku
- associated Heroku review app works correctly with introduced changes

### Deploy notes

N/A

### References
N/A
