### PR TITLE
Convert field names for local storage

### DIFF
--- a/app/storages/local_storage.rb
+++ b/app/storages/local_storage.rb
@@ -1,10 +1,10 @@
 class LocalStorage < Shrine::Storage::FileSystem
   CONVERSION_FIELDS = {
-    cache_control: 'Cache-Control',
-    content_disposition: 'Content-Disposition',
-    content_encoding: 'Content-Encoding',
-    content_length_range: 'content-length-range',
-    content_type: 'Content-Type'
+    cache_control: "Cache-Control",
+    content_disposition: "Content-Disposition",
+    content_encoding: "Content-Encoding",
+    content_length_range: "content-length-range",
+    content_type: "Content-Type"
   }.freeze
 
   delegate :images_upload_url, to: :url_helpers


### PR DESCRIPTION
### Summary

This PR renames fields for local file storage that they will the same as for AWS S3

### How it works

![image](https://user-images.githubusercontent.com/58729845/139296840-3cc36ca8-9cbd-426d-b9e1-ea76ae673a7a.png)

### Test plan

List of steps to manually test introduced functionality:

* Open GraphiQL App
* Make request using schema:
```
mutation {
  presignData(
    input: {
      type: "image/png"
      filename: "avatar.png"
    }
  ) {
  	url
    fields { key, value }
  }
}
```

### Review notes

While reviewing pull-request (especially when it's your pull-request),
please make sure that:

- you understand what problem is solved by PR and how is it solved
- new tests are in place, no redundant tests
- DB schema changes reflect new migrations
- newly introduced DB fields have indexes and constraints
- there are no missed files (migrations, view templates)
- required ENV variables added and described in `.env.example` and added to Heroku
- associated Heroku review app works correctly with introduced changes

### Deploy notes

Notes regarding deployment the contained body of work.
These should note any db migrations, ENV variables, services, scripts, etc.

### References
* Resolves #161 Issue
