### PR TITLE
Add ability to trigger event in resolvers

### DIFF
--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -30,6 +30,8 @@ class GraphqlController < ApplicationController
   end
 
   def trigger_events
+    return if execute_query.context[:trigger_events].blank?
+
     execute_query.context[:trigger_events].reject(&:blank?).each do |trigger_event|
       ActiveSupport::Notifications.instrument trigger_event.event, trigger_event.options
     end

--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -1,5 +1,7 @@
 class GraphqlController < ApplicationController
   def execute
+    trigger_events if execution_success?
+
     render json: execute_query
   rescue StandardError => e
     raise e unless Rails.env.development?
@@ -10,7 +12,7 @@ class GraphqlController < ApplicationController
   private
 
   def execute_query
-    ApplicationSchema.execute(
+    @execute_query ||= ApplicationSchema.execute(
       params[:query],
       variables: ensure_hash(params[:variables]),
       context: execution_context.deep_symbolize_keys,
@@ -25,6 +27,16 @@ class GraphqlController < ApplicationController
       token_payload: payload,
       extensions: ensure_hash(params[:extensions])
     }
+  end
+
+  def trigger_events
+    execute_query.context[:trigger_events].reject(&:blank?).each do |trigger_event|
+      ActiveSupport::Notifications.instrument trigger_event.event, trigger_event.options
+    end
+  end
+
+  def execution_success?
+    execute_query.to_h["errors"].blank?
   end
 
   def ensure_hash(ambiguous_param)

--- a/app/graphql/concerns/triggerable_events.rb
+++ b/app/graphql/concerns/triggerable_events.rb
@@ -1,0 +1,10 @@
+module TriggerableEvents
+  extend ActiveSupport::Concern
+
+  private
+
+  def append_trigger_event(trigger_event)
+    context[:trigger_events] ||= []
+    context[:trigger_events] << trigger_event
+  end
+end

--- a/app/graphql/resolvers/base.rb
+++ b/app/graphql/resolvers/base.rb
@@ -1,11 +1,13 @@
 module Resolvers
   class Base < GraphQL::Schema::Resolver
     include ActionPolicy::GraphQL::Behaviour
+    include TriggerableEvents
 
     argument_class Types::BaseArgument
 
     def resolve(**options)
       @options = options
+      append_trigger_event(trigger_event) if trigger_event.present?
       fetch_data
     end
 
@@ -19,6 +21,9 @@ module Resolvers
 
     def current_user
       @current_user ||= context[:current_user]
+    end
+
+    def trigger_event
     end
   end
 end

--- a/app/models/trigger_event.rb
+++ b/app/models/trigger_event.rb
@@ -1,0 +1,1 @@
+TriggerEvent = Struct.new(:event, :options, keyword_init: true)

--- a/config/initializers/events.rb
+++ b/config/initializers/events.rb
@@ -1,0 +1,3 @@
+# ActiveSupport::Notifications.subscribe "some_event" do |_name, _start, _finish, _id, payload|
+#   # do something
+# end


### PR DESCRIPTION
### Summary

Added ability to trigger events in GraphQL resolvers.

**Problem:**
- When we use resolver we cannot make some changed in DB because GraphQL resolvers are used to read data

**Case when you can use it:**
- You want to track activity when user opens some page

**Example of usage:**
```ruby
module Resolvers
  class PollItem < Resolvers::Base
    argument :id, Integer, required: true

    type Types::PollType, null: false

    private

    def fetch_data
      context[:poll] = current_user.received_polls.find(options[:id])
    end

    def trigger_event
      TriggerEvent.new(event: "poll_opened", options: { poll_id: options[:id] })
    end
  end
end
```

```ruby
# config/initializers/events.rb
ActiveSupport::Notifications.subscribe "poll_opened" do |_name, _start, _finish, _id, payload|
  # do something
end

```
### How it works


### Test plan

None

### Review notes

While reviewing pull-request (especially when it's your pull-request),
please make sure that:

- you understand what problem is solved by PR and how is it solved
- new tests are in place, no redundant tests
- DB schema changes reflect new migrations
- newly introduced DB fields have indexes and constraints
- there are no missed files (migrations, view templates)
- required ENV variables added and described in `.env.example` and added to Heroku
- associated Heroku review app works correctly with introduced changes

### Deploy notes

None

### References
None
