### PR TITLE
Use previous redis protocol

### DIFF
--- a/app/graphql/application_schema.rb
+++ b/app/graphql/application_schema.rb
@@ -8,7 +8,7 @@ class ApplicationSchema < GraphQL::Schema
   use GraphQL::PersistedQueries,
       compiled_queries: true,
       store: :redis_with_local_cache,
-      redis_client: -> { RedisClient.new(url: ENV.fetch("REDIS_URL", "redis://localhost:6379/1")) }
+      redis_client: -> { RedisClient.new(url: ENV.fetch("REDIS_URL", "redis://localhost:6379/1"), protocol: 2) }
 
   max_complexity 250
   max_depth 10

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -5,9 +5,9 @@ Rails.application.configure do
 end
 
 Sidekiq.configure_server do |config|
-  config.redis = { url: ENV.fetch("REDIS_URL", "redis://localhost:6379/1") }
+  config.redis = { url: ENV.fetch("REDIS_URL", "redis://localhost:6379/1"), protocol: 2 }
 end
 
 Sidekiq.configure_client do |config|
-  config.redis = { url: ENV.fetch("REDIS_URL", "redis://localhost:6379/1") }
+  config.redis = { url: ENV.fetch("REDIS_URL", "redis://localhost:6379/1"), protocol: 2 }
 end


### PR DESCRIPTION
### Summary

The Redis cloud provided used on production does not [support redis protocol](https://github.com/sidekiq/sidekiq/blob/main/docs/7.0-Upgrade.md#known-issues) 3. Switching back to protocol 2 temporary.

### How it works

Screenshots/screencasts of the pull request introduced functionality.

### Test plan

List of steps to manually test introduced functionality:

* Open GraphiQL App
* Make request using schema:
```
  query {
    me: {
      id
      name
    }
  }
```
* ...

### Review notes

While reviewing pull-request (especially when it's your pull-request),
please make sure that:

- you understand what problem is solved by PR and how is it solved
- new tests are in place, no redundant tests
- DB schema changes reflect new migrations
- newly introduced DB fields have indexes and constraints
- there are no missed files (migrations, view templates)
- required ENV variables added and described in `.env.example` and added to Heroku
- associated Heroku review app works correctly with introduced changes

### Deploy notes

Notes regarding deployment the contained body of work.
These should note any db migrations, ENV variables, services, scripts, etc.

### References
* Resolves #### Issue
* [GitHub Pull Request ####](https://github.com/fs/rails-base-graphql-api/pull/####)
